### PR TITLE
MSIS 2.0

### DIFF
--- a/cmake/libraries.cmake
+++ b/cmake/libraries.cmake
@@ -16,9 +16,6 @@ if(CMAKE_VERSION VERSION_LESS 3.19)
   set(hwm14_url https://github.com/space-physics/hwm14.git)
   set(hwm14_tag 357d5c2)
 
-  set(msis2_url https://map.nrl.navy.mil/map/pub/nrl/NRLMSIS/NRLMSIS2.0/NRLMSIS2.0.zip)
-  set(msis2_sha1 fa817dfee637ec2298a6ec882345d13d0b087a85)
-
   set(mumps_url https://github.com/scivision/mumps.git)
   set(mumps_tag v5.3.5.2)
 
@@ -48,9 +45,6 @@ string(JSON h5fortran_tag GET ${_libj} "h5fortran" "tag")
 
 string(JSON hwm14_url GET ${_libj} "hwm14" "url")
 string(JSON hwm14_tag GET ${_libj} "hwm14" "tag")
-
-string(JSON msis2_url GET ${_libj} "msis2" "url")
-string(JSON msis2_sha1 GET ${_libj} "msis2" "sha1")
 
 string(JSON mumps_url GET ${_libj} "mumps" "url")
 string(JSON mumps_tag GET ${_libj} "mumps" "tag")

--- a/cmake/msis2.cmake
+++ b/cmake/msis2.cmake
@@ -21,9 +21,7 @@ endif()
 # MSIS 2.0 needs this parm file.
 # From your Fortran code, refer to this file by
 # `call msisinit(parmpath=)` perhaps via CMake configure_file()
-if(NOT EXISTS ${PROJECT_BINARY_DIR}/msis20.parm)
-  file(COPY ${msis2proj_SOURCE_DIR}/msis20.parm DESTINATION ${PROJECT_BINARY_DIR})
-endif()
+file(COPY ${msis2proj_SOURCE_DIR}/msis20.parm DESTINATION ${PROJECT_BINARY_DIR})
 
 if(BUILD_TESTING)
   add_executable(msis2test ${msis2proj_SOURCE_DIR}/msis2.0_test.F90)
@@ -31,5 +29,5 @@ if(BUILD_TESTING)
 
   add_test(NAME MSIS2
     COMMAND $<TARGET_FILE:msis2test>
-    WORKING_DIRECTORY ${msis2proj_BINARY_DIR})
+    WORKING_DIRECTORY ${msis2proj_SOURCE_DIR})
 endif()

--- a/cmake/test_setup.cmake
+++ b/cmake/test_setup.cmake
@@ -17,9 +17,12 @@ endif(mpi)
 if(hdf5)
 
 add_test(NAME gemini:hdf5:${testname}:dryrun
-  COMMAND ${_cmd} -dryrun
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-  # NOTE: Working_Diretory is NECESSARY for Windows + Intel + HDF5
+  COMMAND ${_cmd} -dryrun)
+# we prefer default WorkingDirectory of PROJECT_BINARY_DIR to make MSIS 2.0 msis20.parm use simpler
+# otherwise, we have to generate source for msis_interface.f90
+
+  # WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  # NOTE: WorkingDirectory is NECESSARY for Windows + Intel + ProgramFiles/HDFGroup/HDF5
 
 set_tests_properties(gemini:hdf5:${testname}:dryrun PROPERTIES
   TIMEOUT 60
@@ -29,9 +32,8 @@ set_tests_properties(gemini:hdf5:${testname}:dryrun PROPERTIES
 
 
 add_test(NAME gemini:hdf5:${testname}
-  COMMAND ${_cmd}
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
-  # NOTE: Working_Directory is NECESSARY for Windows + Intel + HDF5
+  COMMAND ${_cmd})
+  # WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 # NOTE: don't use REQUIRED_FILES because it won't let file download if not present.
 set_tests_properties(gemini:hdf5:${testname} PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,8 @@ target_link_libraries(multifluid PRIVATE advec calculus collision const diffusio
 configure_file(gemini_cli.in.f90 gemini_cli.f90 @ONLY)
 add_executable(gemini.bin gemini.f90 ${CMAKE_CURRENT_BINARY_DIR}/gemini_cli.f90)
 set_target_properties(gemini.bin PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
-target_link_libraries(gemini.bin PRIVATE advec calculus config const collision diffusion fang grid io interp ionization gbsv mesh mpimod multifluid
+target_link_libraries(gemini.bin PRIVATE advec calculus config const collision diffusion fang grid io interp ionization gbsv mesh mpimod
+  msis_ifc multifluid
   neutral pathlib PDEelliptic PDEparabolic potential precipBCs reader sanity_check sources temporal timeutils)
 target_link_libraries(gemini.bin PRIVATE MUMPS::MUMPS)
 

--- a/src/io/config.f90
+++ b/src/io/config.f90
@@ -59,6 +59,7 @@ real(wp) :: v0equator=10._wp      ! max vertical drift of plasma at equator for 
 !> varying neutral atmosphere background
 logical :: flagneuBG=.false.                ! whether or not to allow MSIS to be called to update neutral background
 real(wp) :: dtneuBG=900._wp                  ! approximate time between MSIS calls
+integer :: msis_version
 
 !> background preciptation
 real(wp) :: PhiWBG=1e-3_wp                      ! background total energy flux in mW/m^2

--- a/src/io/config_nml.f90
+++ b/src/io/config_nml.f90
@@ -33,8 +33,11 @@ real(wp) :: dtE0=0
 real(wp) :: dtglow=0, dtglowout=0
 logical :: flagEIA
 real(wp) :: v0equator
-logical :: flagneuBG
+
+logical :: flagneuBG=.false.
 real(wp) :: dtneuBG
+integer :: msis_version = 0
+
 real(wp) :: PhiWBG,W0BG
 logical :: flagJpar
 logical :: flgcap
@@ -54,7 +57,7 @@ namelist /efield/ dtE0, E0_dir
 namelist /fang/ flag_fang
 namelist /glow/ dtglow, dtglowout
 namelist /EIA/ flagEIA,v0equator
-namelist /neutral_BG/ flagneuBG,dtneuBG
+namelist /neutral_BG/ flagneuBG,dtneuBG, msis_version
 namelist /precip_BG/ PhiWBG,W0BG
 namelist /Jpar/ flagJpar
 namelist /capacitance/ flagcap,magcap     ! later need to regroup these in a way that is more logical now there are so many more inputs
@@ -180,6 +183,7 @@ if (namelist_exists(u,'neutral_BG')) then
   call check_nml_io(i, cfg%infile, "neutral_BG")
   cfg%flagneuBG=flagneuBG
   cfg%dtneuBG=dtneuBG
+  cfg%msis_version = msis_version
 else
   cfg%flagneuBG=.false.
 end if

--- a/src/ionization/fang_run.f90
+++ b/src/ionization/fang_run.f90
@@ -5,7 +5,7 @@ module ionrate
 use phys_consts, only: wp
 use, intrinsic:: iso_fortran_env, only: sp=>real32
 use ionize_fang, only: fang2008, fang2010, gravity_accel, erg2kev
-use msis_interface, only : msis_gtd7
+use msis_interface, only : msis_gtd7, msis_gtd8
 
 implicit none (type, external)
 private
@@ -13,17 +13,24 @@ public :: ionization_fang2008, ionization_fang2010
 
 contains
 
-impure elemental real(wp) function ionization_fang2008(Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, doy, UTsec) result(Qtot)
+impure elemental real(wp) function ionization_fang2008(Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, doy, UTsec, &
+  msis_version) result(Qtot)
 
 real(wp), intent(in) :: Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, UTsec
-integer, intent(in) :: doy
+integer, intent(in) :: doy, msis_version
 
 real(wp) :: massden_gcm3, meanmass_g
 real(wp) :: d(9),T(2), Ap7(7)
 
 Ap7 = Ap
 
-call msis_gtd7(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters=.false.)
+if(msis_version==0) then
+  call msis_gtd7(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters=.false.)
+elseif(msis_version==20) then
+  error stop 'TODO: MSIS 2.0 for Fang unit tests'
+else
+  error stop 'expected msis_version == {0,20}'
+endif
 
 massden_gcm3 = d(6)  ! [g cm^-3]
 meanmass_g = massden_gcm3 / (sum(d(1:5)) + sum(d(7:8)))
@@ -33,17 +40,24 @@ Qtot = fang2008(Q0_erg*erg2kev, E0_keV, T(2), massden_gcm3, meanmass_g, gravity_
 end function ionization_fang2008
 
 
-impure elemental real(wp) function ionization_fang2010(Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, doy, UTsec) result(Qtot)
+impure elemental real(wp) function ionization_fang2010(Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, doy, UTsec, &
+  msis_version) result(Qtot)
 
 real(wp), intent(in) :: Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, UTsec
-integer, intent(in) :: doy
+integer, intent(in) :: doy, msis_version
 
 real(wp) :: massden_gcm3, meanmass_g
 real(wp) :: d(9),T(2), Ap7(7)
 
 Ap7 = Ap
 
-call msis_gtd7(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters=.false.)
+if(msis_version==0) then
+  call msis_gtd7(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters=.false.)
+elseif(msis_version==20) then
+  error stop 'TODO: MSIS 2.0 for Fang unit tests'
+else
+  error stop 'expected msis_version == {0,20}'
+endif
 
 massden_gcm3 = d(6)  ! [g cm^-3]
 meanmass_g = massden_gcm3 / (sum(d(1:5)) + sum(d(7:8)))
@@ -52,4 +66,4 @@ Qtot = fang2010(Q0_erg*erg2kev, E0_keV, T(2), massden_gcm3, meanmass_g, gravity_
 
 end function ionization_fang2010
 
-end module
+end module ionrate

--- a/src/ionization/fang_run.f90
+++ b/src/ionization/fang_run.f90
@@ -5,6 +5,7 @@ module ionrate
 use phys_consts, only: wp
 use, intrinsic:: iso_fortran_env, only: sp=>real32
 use ionize_fang, only: fang2008, fang2010, gravity_accel, erg2kev
+use msis_interface, only : msis_gtd7
 
 implicit none (type, external)
 private
@@ -18,22 +19,16 @@ real(wp), intent(in) :: Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, UTs
 integer, intent(in) :: doy
 
 real(wp) :: massden_gcm3, meanmass_g
-real(sp) :: stl, d(9),T(2), sw(25), Ap7(7)
+real(wp) :: d(9),T(2), Ap7(7)
 
-external :: meters, gtd7, tselec
+Ap7 = Ap
 
-!! MSIS setup
-Ap7 = real(Ap, sp)
-stl = real(UTsec/3600 + glon/15, sp)
-call meters(.false.)
-sw = 1
-call tselec(sw)
-call gtd7(doy, real(UTsec, sp), real(alt_km, sp), real(glat, sp), real(glon, sp), stl, &
-          real(f107a, sp), real(f107, sp), Ap7, 48, d, T)
+call msis_gtd7(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters=.false.)
+
 massden_gcm3 = d(6)  ! [g cm^-3]
 meanmass_g = massden_gcm3 / (sum(d(1:5)) + sum(d(7:8)))
 
-Qtot = fang2008(Q0_erg*erg2kev, E0_keV, real(T(2), wp), massden_gcm3, meanmass_g, real(gravity_accel(alt_km), wp))
+Qtot = fang2008(Q0_erg*erg2kev, E0_keV, T(2), massden_gcm3, meanmass_g, gravity_accel(alt_km))
 
 end function ionization_fang2008
 
@@ -44,22 +39,16 @@ real(wp), intent(in) :: Q0_erg, E0_keV, alt_km, f107, f107a, Ap, glat, glon, UTs
 integer, intent(in) :: doy
 
 real(wp) :: massden_gcm3, meanmass_g
-real(sp) :: stl, d(9),T(2), sw(25), Ap7(7)
+real(wp) :: d(9),T(2), Ap7(7)
 
-external :: meters, gtd7, tselec
+Ap7 = Ap
 
-!! MSIS setup
-Ap7 = real(Ap, sp)
-stl = real(UTsec/3600 + glon/15, sp)
-call meters(.false.)
-sw = 1
-call tselec(sw)
-call gtd7(doy, real(UTsec, sp), real(alt_km, sp), real(glat, sp), real(glon, sp), stl, &
-          real(f107a, sp), real(f107, sp), Ap7, 48, d, T)
+call msis_gtd7(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters=.false.)
+
 massden_gcm3 = d(6)  ! [g cm^-3]
 meanmass_g = massden_gcm3 / (sum(d(1:5)) + sum(d(7:8)))
 
-Qtot = fang2010(Q0_erg*erg2kev, E0_keV, real(T(2), wp), massden_gcm3, meanmass_g, real(gravity_accel(alt_km), wp))
+Qtot = fang2010(Q0_erg*erg2kev, E0_keV, T(2), massden_gcm3, meanmass_g, gravity_accel(alt_km))
 
 end function ionization_fang2010
 

--- a/src/ionization/test_fang.f90
+++ b/src/ionization/test_fang.f90
@@ -1,5 +1,4 @@
 Program test_fang
-!! Need program statement for FORD
 !! Reproduces data of:
 !! * Figure 3 in https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2008JA013384
 !! * Figure 2 in Fang 2010
@@ -64,8 +63,8 @@ allocate(Qtot08(size(alt_km), size(E0_keV)), Qtot10(size(alt_km), size(E0_keV)))
 
 
 do i = 1, size(alt_km)
-  Qtot08(i, :) = ionization_fang2008(Q0_erg, E0_keV, alt_km(i), f107, f107a, Ap, glat, glon, doy, UTsec)
-  Qtot10(i, :) = ionization_fang2010(Q0_erg, E0_keV, alt_km(i), f107, f107a, Ap, glat, glon, doy, UTsec)
+  Qtot08(i, :) = ionization_fang2008(Q0_erg, E0_keV, alt_km(i), f107, f107a, Ap, glat, glon, doy, UTsec, msis_version=0)
+  Qtot10(i, :) = ionization_fang2010(Q0_erg, E0_keV, alt_km(i), f107, f107a, Ap, glat, glon, doy, UTsec, msis_version=0)
 enddo
 
 print '(A,25F10.1)', 'alt[km]/E0[keV]', E0_keV

--- a/src/neutral/CMakeLists.txt
+++ b/src/neutral/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(neutral OBJECT neutral.f90 atmos.f90 interp.f90 perturb.f90 proj.f90)
 target_compile_options(neutral PRIVATE ${gcc10opts})
-target_link_libraries(neutral PRIVATE const reader grid mesh interp mpimod msis_ifc timeutils MPI::MPI_Fortran)
+target_link_libraries(neutral PRIVATE config const reader grid mesh interp mpimod msis_ifc timeutils MPI::MPI_Fortran)

--- a/src/neutral/atmos.f90
+++ b/src/neutral/atmos.f90
@@ -52,7 +52,7 @@ do ix3=1,lx3
           f107a=activ(1), f107=activ(2), ap7=ap, &
           d=d, T=t, use_meters=.true.)
       elseif(msis_version == 20) then
-        call msis_gtd8(doy=real(doy, wp), UTsec=UTsecd, &
+        call msis_gtd8(doy=doy, UTsec=UTsecd, &
           alt_km=altnow, glat=glat(ix1,ix2,ix3), glon=glon(ix1,ix2,ix3), &
           f107a=activ(1), f107=activ(2), ap7=ap, &
           Dn=d, Tn=t)

--- a/src/neutral/atmos.f90
+++ b/src/neutral/atmos.f90
@@ -3,6 +3,7 @@ submodule (neutral) atmos
 use, intrinsic :: iso_fortran_env, only: sp => real32
 
 use timeutils, only : doy_calc
+use msis_interface, only : msis_gtd7
 
 implicit none (type, external)
 
@@ -15,13 +16,11 @@ module procedure neutral_atmos
 
 integer :: ix1,ix2,ix3,lx1,lx2,lx3
 
-integer :: iyd,mass=48
-integer :: dom,month,year,doy,yearshort
-real(sp) :: sec,f107a,f107,ap(7),stl,ap3
-real(sp) :: altnow,latnow,lonnow
-real(sp) :: d(9),t(2)
-
-external :: meters, gtd7
+integer :: iyd
+integer :: year,doy,yearshort
+real(wp) :: sec,ap(7),ap3
+real(wp) :: altnow
+real(wp) :: d(9),t(2)
 
 !   real(wp), dimension(1:size(alt,1),1:size(alt,2),1:size(alt,3)) :: nnow
 !    real(wp), dimension(1:size(alt,1),1:size(alt,2),1:size(alt,3)) :: altalt    !an alternate altitude variable which fixes below ground values to 1km
@@ -33,45 +32,39 @@ lx3=size(alt,3)
 
 
 !! CONVERT DATE INFO INTO EXPECTED FORM AND KIND
-f107a=real(activ(1),sp)
-f107=real(activ(2),sp)
-ap=real(activ(3),sp)
-ap3=real(activ(3),sp)
-dom=ymd(3)
-month=ymd(2)
-year=ymd(1)
-doy=doy_calc(year, month, dom)
-yearshort=mod(year,100)
-iyd=yearshort*1000+doy
-sec=floor(UTsecd)
+ap= activ(3)
+ap3= activ(3)
+
+doy=doy_calc(year=ymd(1), month=ymd(2), day=ymd(3))
+
+yearshort = mod(ymd(1), 100)
+iyd = yearshort*1000+doy
+sec = floor(UTsecd)
 
 ap(2)=ap3   !superfluous for now
 
 
 !> ITERATED LAT, LON, ALT DATA
-call meters(.true.)    !switch to mksa units
 
 do ix3=1,lx3
   do ix2=1,lx2
     do ix1=1,lx1
-      altnow=real(alt(ix1,ix2,ix3)/1000,sp)
+      altnow= alt(ix1,ix2,ix3)/1000
       if (altnow < 0) then
         altnow = 1     !so that MSIS does not get called with below ground values and so that we set them to something sensible that won't mess up the conductance calculations
       end if
 
-      latnow=real(glat(ix1,ix2,ix3),sp)
-      lonnow=real(glon(ix1,ix2,ix3),sp)
+      call msis_gtd7(iyd,sec, &
+        alt_km=altnow, glat=glat(ix1,ix2,ix3), glon=glon(ix1,ix2,ix3), &
+        f107a=activ(1), f107=activ(2), ap7=ap, d=d, T=t, use_meters=.true.)
 
-      stl=sec/3600.0+lonnow/15.0
-      call gtd7(iyd,sec,altnow,latnow,lonnow,stl,f107a,f107,ap,mass,d,t)
+      nnmsis(ix1,ix2,ix3,1)= d(2)
+      nnmsis(ix1,ix2,ix3,2)= d(3)
+      nnmsis(ix1,ix2,ix3,3)= d(4)
+      nnmsis(ix1,ix2,ix3,4)= d(7)
+      nnmsis(ix1,ix2,ix3,5)= d(8)
 
-      nnmsis(ix1,ix2,ix3,1)=real(d(2),wp)
-      nnmsis(ix1,ix2,ix3,2)=real(d(3),wp)
-      nnmsis(ix1,ix2,ix3,3)=real(d(4),wp)
-      nnmsis(ix1,ix2,ix3,4)=real(d(7),wp)
-      nnmsis(ix1,ix2,ix3,5)=real(d(8),wp)
-
-      Tnmsis(ix1,ix2,ix3)=real(t(2),wp)
+      Tnmsis(ix1,ix2,ix3)= t(2)
       nnmsis(ix1,ix2,ix3,6)=0.4_wp*exp(-3700/Tnmsis(ix1,ix2,ix3))*nnmsis(ix1,ix2,ix3,3)+ &
                           5e-7_wp*nnmsis(ix1,ix2,ix3,1)   !Mitra, 1968
     end do

--- a/src/neutral/atmos.f90
+++ b/src/neutral/atmos.f90
@@ -16,30 +16,23 @@ module procedure neutral_atmos
 
 integer :: ix1,ix2,ix3,lx1,lx2,lx3
 
-integer :: iyd
-integer :: year,doy,yearshort
-real(wp) :: sec,ap(7),ap3
+integer :: doy
+real(wp) :: ap(7),ap3
 real(wp) :: altnow
 real(wp) :: d(9),t(2)
 
 !   real(wp), dimension(1:size(alt,1),1:size(alt,2),1:size(alt,3)) :: nnow
 !    real(wp), dimension(1:size(alt,1),1:size(alt,2),1:size(alt,3)) :: altalt    !an alternate altitude variable which fixes below ground values to 1km
 
-
 lx1=size(alt,1)
 lx2=size(alt,2)
 lx3=size(alt,3)
 
-
 !! CONVERT DATE INFO INTO EXPECTED FORM AND KIND
-ap= activ(3)
-ap3= activ(3)
+ap = activ(3)
+ap3 = activ(3)
 
-doy=doy_calc(year=ymd(1), month=ymd(2), day=ymd(3))
-
-yearshort = mod(ymd(1), 100)
-iyd = yearshort*1000+doy
-sec = floor(UTsecd)
+doy = doy_calc(year=ymd(1), month=ymd(2), day=ymd(3))
 
 ap(2)=ap3   !superfluous for now
 
@@ -54,12 +47,12 @@ do ix3=1,lx3
       end if
 
       if(msis_version == 0) then
-        call msis_gtd7(iyd, UTsec=sec, &
+        call msis_gtd7(doy=doy, UTsec=UTsecd, &
           alt_km=altnow, glat=glat(ix1,ix2,ix3), glon=glon(ix1,ix2,ix3), &
           f107a=activ(1), f107=activ(2), ap7=ap, &
           d=d, T=t, use_meters=.true.)
       elseif(msis_version == 20) then
-        call msis_gtd8(doy=real(doy, wp), UTsec=sec, &
+        call msis_gtd8(doy=real(doy, wp), UTsec=UTsecd, &
           alt_km=altnow, glat=glat(ix1,ix2,ix3), glon=glon(ix1,ix2,ix3), &
           f107a=activ(1), f107=activ(2), ap7=ap, &
           Dn=d, Tn=t)

--- a/src/neutral/neutral.f90
+++ b/src/neutral/neutral.f90
@@ -15,8 +15,8 @@ public :: Tnmsis, neutral_atmos, make_dneu, clear_dneu, neutral_perturb, neutral
 
 
 interface ! atmos.f90
-module subroutine neutral_atmos(ymd,UTsecd,glat,glon,alt,activ,v2grid,v3grid,nn,Tn,vn1,vn2,vn3)
-integer, intent(in) :: ymd(3)
+module subroutine neutral_atmos(ymd,UTsecd,glat,glon,alt,activ,v2grid,v3grid,nn,Tn,vn1,vn2,vn3, msis_version)
+integer, intent(in) :: ymd(3), msis_version
 real(wp), intent(in) :: UTsecd
 real(wp), dimension(:,:,:), intent(in) :: glat,glon,alt
 real(wp), intent(in) :: activ(3)
@@ -137,7 +137,7 @@ call make_dneu()
 
 !! call msis to get an initial neutral background atmosphere
 if (mpi_cfg%myid == 0) call cpu_time(tstart)
-call neutral_atmos(ymd,UTsec,x%glat,x%glon,x%alt,cfg%activ,v2grid,v3grid,nn,Tn,vn1,vn2,vn3)
+call neutral_atmos(ymd,UTsec,x%glat,x%glon,x%alt,cfg%activ,v2grid,v3grid,nn,Tn,vn1,vn2,vn3, cfg%msis_version)
 if (mpi_cfg%myid == 0) then
   call cpu_time(tfin)
   print *, 'Initial neutral background at time:  ',ymd,UTsec,' calculated in time:  ',tfin-tstart

--- a/src/neutral/neutral.f90
+++ b/src/neutral/neutral.f90
@@ -7,7 +7,7 @@ use timeutils, only : find_lastdate
 use mpimod, only: mpi_cfg
 use config, only: gemini_cfg
 
-! also links gtd7 from vendor/msis00/
+! also links MSIS from vendor/msis00/
 
 implicit none (type, external)
 private

--- a/src/vendor/msis00/CMakeLists.txt
+++ b/src/vendor/msis00/CMakeLists.txt
@@ -41,6 +41,7 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
 endif()
 
 add_library(msis00 msis00_gfortran.f)
+# keep msis00 NOT an OBJECT to avoid having to link it explicitly everywhere
 target_compile_options(msis00 PRIVATE ${msis_flags})
 
 # --- for setting up an equilibrium simulation --
@@ -77,7 +78,12 @@ endfunction(build_msis00)
 
 build_msis00()
 
-add_library(msis_ifc ALIAS msis00)
+add_library(msis_ifc OBJECT msis_interface.f90)
+target_link_libraries(msis_ifc PRIVATE msis00)
+target_include_directories(msis_ifc INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)
+set_target_properties(msis_ifc PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
+
+
 if(msis20)
   # provides gtd8() subroutine
   include(${PROJECT_SOURCE_DIR}/cmake/msis2.cmake)

--- a/src/vendor/msis00/CMakeLists.txt
+++ b/src/vendor/msis00/CMakeLists.txt
@@ -47,7 +47,7 @@ target_compile_options(msis00 PRIVATE ${msis_flags})
 # --- for setting up an equilibrium simulation --
 
 add_executable(msis_setup msis_driver.f90)
-target_link_libraries(msis_setup PRIVATE msis00)
+target_link_libraries(msis_setup PRIVATE msis_ifc)
 target_compile_options(msis_setup PRIVATE ${static_flag})
 set_target_properties(msis_setup PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 
@@ -57,7 +57,7 @@ if(${PROJECT_NAME}_BUILD_TESTING)
 
   if(NOT EXISTS ${_msis_in})
     file(WRITE ${_msis_in} "
-    15123
+    123
     12345
     100, 100, 4, 5
     ${_msis_lz}

--- a/src/vendor/msis00/CMakeLists.txt
+++ b/src/vendor/msis00/CMakeLists.txt
@@ -85,6 +85,10 @@ set_target_properties(msis_ifc PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRE
 
 
 if(msis20)
-  # provides gtd8() subroutine
-  include(${PROJECT_SOURCE_DIR}/cmake/msis2.cmake)
-endif()
+  # we here use cmake_current_source_dir to allow use from other projects
+  # that start from this CMakeLists.txt by add_subdirectory(../gemini3d/src/vendor/msis00)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/msis2.cmake)
+  target_link_libraries(msis_ifc PRIVATE msis2)
+else(msis20)
+  target_sources(msis_ifc PRIVATE msis2_dummy.f90)
+endif(msis20)

--- a/src/vendor/msis00/CMakeLists.txt
+++ b/src/vendor/msis00/CMakeLists.txt
@@ -64,9 +64,9 @@ set_target_properties(msis_ifc PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_CURRE
 
 
 if(msis20)
-  # we here use cmake_current_source_dir to allow use from other projects
+  # must have msis2.cmake in this directory to allow use from other projects
   # that start from this CMakeLists.txt by add_subdirectory(../gemini3d/src/vendor/msis00)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/msis2.cmake)
+  include(msis2.cmake)
   target_link_libraries(msis_ifc PRIVATE msis2)
 else(msis20)
   target_sources(msis_ifc PRIVATE msis2_dummy.f90)

--- a/src/vendor/msis00/CMakeLists.txt
+++ b/src/vendor/msis00/CMakeLists.txt
@@ -51,27 +51,6 @@ target_link_libraries(msis_setup PRIVATE msis_ifc)
 target_compile_options(msis_setup PRIVATE ${static_flag})
 set_target_properties(msis_setup PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 
-if(${PROJECT_NAME}_BUILD_TESTING)
-  set(_msis_in ${CMAKE_CURRENT_BINARY_DIR}/msis_in.txt)
-  set(_msis_lz 4)
-
-  if(NOT EXISTS ${_msis_in})
-    file(WRITE ${_msis_in} "
-    123
-    12345
-    100, 100, 4, 5
-    ${_msis_lz}
-    40, 50, 60, 70
-    0, 20, 40, 60
-    100,110,150,200
-    ")
-  endif()
-
-  add_test(NAME unit:MSISsetup COMMAND $<TARGET_FILE:msis_setup> ${_msis_in} "-" ${_msis_lz})
-  set_tests_properties(unit:MSISsetup PROPERTIES
-    PASS_REGULAR_EXPRESSION "^[ ]*100.00.*110.00.*150.00.*200.00.*862.8.")
-endif(${PROJECT_NAME}_BUILD_TESTING)
-
 endfunction(build_msis00)
 
 #--------------------------
@@ -92,3 +71,34 @@ if(msis20)
 else(msis20)
   target_sources(msis_ifc PRIVATE msis2_dummy.f90)
 endif(msis20)
+
+
+if(${PROJECT_NAME}_BUILD_TESTING)
+  set(_msis_in ${CMAKE_CURRENT_BINARY_DIR}/msis_in.txt)
+  set(_msis_lz 2)
+
+  if(NOT EXISTS ${_msis_in})
+    file(WRITE ${_msis_in} "
+    123
+    12345
+    100, 100, 4, 5
+    ${_msis_lz}
+    40, 70
+    0, 60
+    100,200
+    ")
+  endif()
+
+  add_test(NAME unit:MSIS00:setup
+    COMMAND $<TARGET_FILE:msis_setup> ${_msis_in} "-" ${_msis_lz} 0)
+  set_tests_properties(unit:MSIS00:setup PROPERTIES
+    PASS_REGULAR_EXPRESSION "^[ ]*100.00.*200.00.*862.8.")
+
+  if(msis20)
+    add_test(NAME unit:MSIS2.0:setup
+      COMMAND $<TARGET_FILE:msis_setup> ${_msis_in} "-" ${_msis_lz} 20
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    set_tests_properties(unit:MSIS2.0:setup PROPERTIES
+      PASS_REGULAR_EXPRESSION "^[ ]*100.00.*200.00.*863.5.")
+  endif(msis20)
+endif(${PROJECT_NAME}_BUILD_TESTING)

--- a/src/vendor/msis00/msis2.cmake
+++ b/src/vendor/msis00/msis2.cmake
@@ -1,6 +1,10 @@
 include(FetchContent)
 
 if(NOT DEFINED msis2_url OR NOT DEFINED msis2_sha1)
+  if(CMAKE_VERSION VERSION_LESS 3.19)
+    message(FATAL_ERROR "CMake >= 3.19 required to use MSIS 2.0")
+  endif()
+
   set(_json_file ${PROJECT_SOURCE_DIR}/cmake/libraries.json)
   if(NOT EXISTS ${_json_file})
     message(FATAL_ERROR "must define msis2_url and msis2_sha1")

--- a/src/vendor/msis00/msis2.cmake
+++ b/src/vendor/msis00/msis2.cmake
@@ -1,5 +1,16 @@
 include(FetchContent)
 
+if(NOT DEFINED msis2_url OR NOT DEFINED msis2_sha1)
+  set(_json_file ${PROJECT_SOURCE_DIR}/cmake/libraries.json)
+  if(NOT EXISTS ${_json_file})
+    message(FATAL_ERROR "must define msis2_url and msis2_sha1")
+  endif()
+  file(READ ${_json_file} _libj)
+
+  string(JSON msis2_url GET ${_libj} "msis2" "url")
+  string(JSON msis2_sha1 GET ${_libj} "msis2" "sha1")
+endif()
+
 FetchContent_Declare(msis2proj
 URL ${msis2_url}
 URL_HASH SHA1=${msis2_sha1}

--- a/src/vendor/msis00/msis2_dummy.f90
+++ b/src/vendor/msis00/msis2_dummy.f90
@@ -1,0 +1,58 @@
+module msis_calc
+
+use, intrinsic :: iso_fortran_env, only : real64, real32
+implicit none (type, external)
+
+interface msiscalc
+  procedure msiscalc_r32, msiscalc_r64
+end interface msiscalc
+
+contains
+
+subroutine msiscalc_r32(day,utsec,z,lat,lon,sfluxavg,sflux,ap,tn,dn,tex)
+
+real(real32), intent(in) :: day,utsec,z,lat,lon,sfluxavg,sflux,ap(7)
+real(real32), intent(out) :: tn, dn(10)
+real(real32), intent(out) :: tex
+
+error stop 'to use MSIS 2.0 requires "cmake -B build -Dmsis20=yes"'
+
+end subroutine msiscalc_r32
+
+
+subroutine msiscalc_r64(day,utsec,z,lat,lon,sfluxavg,sflux,ap,tn,dn,tex)
+
+real(real64), intent(in) :: day,utsec,z,lat,lon,sfluxavg,sflux,ap(7)
+real(real64), intent(out) :: tn, dn(10)
+real(real64), intent(out) :: tex
+
+error stop 'to use MSIS 2.0 requires "cmake -B build -Dmsis20=yes"'
+
+end subroutine msiscalc_r64
+
+end module msis_calc
+
+
+module msis_init
+
+use, intrinsic :: iso_fortran_env, only : real32
+implicit none (type, external)
+
+contains
+
+subroutine msisinit(parmpath,parmfile,iun,switch_gfn,switch_legacy, &
+                      lzalt_type,lspec_select,lmass_include,lN2_msis00)
+
+integer, parameter :: nspec=11, maxnbf=512
+
+character(*), intent(in), optional :: parmpath, parmfile
+integer, intent(in), optional :: iun
+logical, intent(in), optional :: switch_gfn(0:maxnbf-1)
+real(real32), intent(in), optional :: switch_legacy(25)
+logical, intent(in), optional :: lzalt_type,lspec_select(nspec-1), lmass_include(nspec-1), lN2_msis00
+
+error stop 'to use MSIS 2.0 requires "cmake -B build -Dmsis20=yes"'
+
+end subroutine msisinit
+
+end module msis_init

--- a/src/vendor/msis00/msis_driver.f90
+++ b/src/vendor/msis00/msis_driver.f90
@@ -1,43 +1,40 @@
 program msis_driver
 !! will write to stdout if "-" specified, so we avoid printing to console unless file output is used
-use, intrinsic:: iso_fortran_env, only: sp=>real32, stderr=>error_unit, stdout=>output_unit, stdin=>input_unit
 
+use msis_interface, only : msis_gtd7, msis_gtd8, msisinit
+use, intrinsic:: iso_fortran_env, only : sp=>real32, stderr=>error_unit, stdout=>output_unit, stdin=>input_unit
 implicit none (type, external)
 
-integer, parameter :: mass=48
-integer :: iyd,sec,lz, i
-real(sp) :: f107a,f107,ap(7),stl,apday,ap3
+integer :: doy, lz, i
+real(sp) :: sec,f107a,f107,ap(7),apday,ap3
 real(sp) :: d(9),t(2)
 real(sp), allocatable :: glat(:),glon(:),alt(:)
-integer :: u
+integer :: u, msis_version
 character(256) :: buf
 character(:), allocatable :: infile,outfile
 
-external :: meters, gtd7
-
-!> read in msis inputs
+!> user options
 if (command_argument_count() < 2) error stop 'msis_setup: must specify input and output filenames'
 
 call get_command_argument(1,buf)
 infile = trim(buf)
-
-if (infile == "-" .or. infile(len(infile)-3:) == ".txt") then
-  call get_text_input(infile, iyd,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
-else
-  call get_binary_input(infile,iyd,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
-endif
-
-!> Run MSIS
-ap(1:7)=apday
-ap(2)=ap3
-
-!> switch to mksa units
-call meters(.true.)
-
-!> output file
 call get_command_argument(2, buf)
 outfile = trim(buf)
 
+msis_version = 0
+if(command_argument_count() > 3) then
+  call get_command_argument(4, buf)
+  read(buf, '(I3)') msis_version
+endif
+
+!> select input format
+if (infile == "-" .or. infile(len(infile)-3:) == ".txt") then
+  call get_text_input(infile, doy,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
+else
+  call get_binary_input(infile,doy,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
+endif
+
+!> select output format
 if (outfile == '-') then
   u = stdout
 elseif(outfile(len(outfile)-3:) == ".txt") then
@@ -46,10 +43,18 @@ else
   open(newunit=u,file=outfile,status='replace',form='unformatted',access='stream', action='write')
 endif
 
-!> call to msis routine
+!> Run MSIS
+ap(1:7)=apday
+ap(2)=ap3
 do i=1,lz
-  stl = sec/3600. + glon(i)/15.
-  call gtd7(iyd, real(sec, sp),alt(i),glat(i),glon(i),stl,f107a,f107,ap,mass,d,t)
+
+  if(msis_version == 0) then
+    call msis_gtd7(doy, sec, alt(i), glat(i), glon(i), f107a, f107, Ap, D, T, use_meters=.true.)
+  elseif(msis_version == 20) then
+    call msis_gtd8(doy, sec, alt(i), glat(i), glon(i), f107a, f107, Ap, D, T)
+  else
+    error stop 'expected msis_version = {0,20}'
+  endif
 
   if (outfile == '-') then
     write(u,'(F9.2, 9ES15.6, F9.2)') alt(i),d(1:9),t(2)
@@ -70,11 +75,11 @@ if (i==0) error stop 'msis_setup failed to write file'
 
 contains
 
-subroutine get_text_input(filename, iyd,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
+subroutine get_text_input(filename, doy,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
 
 character(*), intent(in) :: filename
-integer, intent(out) :: iyd,sec,lz
-real(sp), intent(out) :: f107a,f107,apday,ap3
+integer, intent(out) :: doy,lz
+real(sp), intent(out) :: sec,f107a,f107,apday,ap3
 real(sp), intent(out), allocatable :: glat(:),glon(:),alt(:)
 integer :: u, i
 
@@ -84,10 +89,10 @@ else
   open(newunit=u, file=filename, status="old", action="read")
 endif
 
-read(u, *, iostat=i) iyd
-if (i/=0) error stop "iyd: integer yyddd"
+read(u, *, iostat=i) doy
+if (i/=0) error stop "doy: integer day of year (1..366)"
 read(u, *, iostat=i) sec
-if (i/=0) error stop "sec: integer seconds since midniight"
+if (i/=0) error stop "sec: seconds since UTC midnight"
 read(u, *, iostat=i) f107a, f107, apday, ap3
 if (i/=0) error stop "expecting: f107a, f107, apday, ap3"
 read(u, *, iostat=i) lz
@@ -114,18 +119,17 @@ if (filename /= "-") close(u)
 end subroutine get_text_input
 
 
-subroutine get_binary_input(filename,iyd,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
-
+subroutine get_binary_input(filename,doy,sec,f107a,f107,apday,ap3,lz, glat, glon, alt)
+!! use binary to reduce file size and read times
 character(*), intent(in) :: filename
-integer, intent(out) :: iyd,sec,lz
-real(sp), intent(out) :: f107a,f107,apday,ap3
+integer, intent(out) :: doy,lz
+real(sp), intent(out) :: sec,f107a,f107,apday,ap3
 real(sp), intent(out), allocatable :: glat(:),glon(:),alt(:)
 
 integer :: u
 open(newunit=u,file=infile, status='old',form='unformatted',access='stream', action='read')
-!! use binary to reduce file size and read times
 
-read(u) iyd
+read(u) doy
 read(u) sec
 read(u) f107a
 read(u) f107
@@ -152,7 +156,7 @@ if (lz<1) error stop 'lz must be positive'
 
 call get_command_argument(3, buf, status=i)
 if (i==0) then
-  read(buf,*) i
+  read(buf, *) i
   if (i /= lz) then
     write(stderr,*) 'expected ',i,' grid points but read ',lz
     error stop

--- a/src/vendor/msis00/msis_driver.f90
+++ b/src/vendor/msis00/msis_driver.f90
@@ -46,6 +46,9 @@ endif
 !> Run MSIS
 ap(1:7)=apday
 ap(2)=ap3
+
+if(msis_version == 20) call msisinit(parmfile='msis20.parm')
+
 do i=1,lz
 
   if(msis_version == 0) then

--- a/src/vendor/msis00/msis_interface.f90
+++ b/src/vendor/msis00/msis_interface.f90
@@ -5,4 +5,66 @@ module msis_interface
 !!
 !! We assume MSISE00 is always available, which MSIS 2.0 might not be available.
 
+use, intrinsic :: iso_fortran_env, only : real32, real64
+implicit none (type, external)
+
+interface msis_gtd7
+  module procedure msis_gtd7_r32, msis_gtd7_r64
+end interface msis_gtd7
+
+contains
+
+subroutine msis_gtd7_r32(doy, UTsec, alt_km,  glat, glon, f107a, f107, Ap7, d, T, use_meters, sw25)
+
+external :: meters, gtd7, tselec
+integer, intent(in) :: doy
+real(real32), intent(in) :: UTsec, alt_km, glat, glon, f107, f107a, Ap7(7)
+real(real32), intent(out) :: d(9),T(2)
+logical, intent(in) :: use_meters
+real(real32), intent(in), optional :: sw25(25)
+
+real(real32) :: stl, sw(25)
+
+stl = UTsec/3600 + glon/15
+
+call meters(use_meters)
+
+sw = 1
+if (present(sw25)) sw = sw25
+call tselec(sw)
+
+call gtd7(doy, UTsec, alt_km, glat, glon, stl, f107a, f107, Ap7, 48, d, T)
+
+end subroutine msis_gtd7_r32
+
+
+subroutine msis_gtd7_r64(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, d, T, use_meters, sw25)
+!! adds casting to/from real32
+external :: meters, gtd7, tselec
+integer, intent(in) :: doy
+real(real64), intent(in) :: UTsec, alt_km, glat, glon, f107, f107a, Ap7(7)
+real(real64), intent(out) :: d(9),T(2)
+logical, intent(in) :: use_meters
+real(real64), intent(in), optional :: sw25(25)
+
+real(real32) :: sw(25), stl, d32(9), T32(2)
+
+stl = real(UTsec/3600 + glon/15, real32)
+
+call meters(use_meters)
+
+sw = 1
+if (present(sw25)) sw = real(sw25, real32)
+call tselec(sw)
+
+call gtd7(doy, real(UTsec, real32), real(alt_km, real32), &
+  real(glat, real32), real(glon, real32), real(stl, real32), &
+  real(f107a, real32), real(f107, real32), real(Ap7, real32), 48, &
+  d32, T32)
+
+d = real(d32, real64)
+T = real(T32, real64)
+
+end subroutine msis_gtd7_r64
+
 end module

--- a/src/vendor/msis00/msis_interface.f90
+++ b/src/vendor/msis00/msis_interface.f90
@@ -5,12 +5,21 @@ module msis_interface
 !!
 !! We assume MSISE00 is always available, which MSIS 2.0 might not be available.
 
+use msis_calc, only : msiscalc
+use msis_init, only :  msisinit
 use, intrinsic :: iso_fortran_env, only : real32, real64
 implicit none (type, external)
 
 interface msis_gtd7
   module procedure msis_gtd7_r32, msis_gtd7_r64
 end interface msis_gtd7
+
+interface msis_gtd8
+  module procedure msis_gtd8_r64, msis_gtd8_r32
+end interface msis_gtd8
+
+private
+public :: msis_gtd7, msis_gtd8, msisinit
 
 contains
 
@@ -66,5 +75,64 @@ d = real(d32, real64)
 T = real(T32, real64)
 
 end subroutine msis_gtd7_r64
+
+
+subroutine msis_gtd8_r64(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, Dn, Tn)
+!! translate MSIS 2.0 to MSISE00 gtd7-like
+!! assume MSIS 2.0 is real32
+real(real64), intent(in) :: doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7(7)
+real(real64), intent(out) :: Dn(9), Tn(2)
+
+real(real32) :: D(10), T(2)
+
+call msiscalc(day=real(doy, real32), UTsec=real(UTsec, real32), &
+  z=real(alt_km, real32), lat=real(glat, real32), lon=real(glon, real32), &
+  SfluxAvg=real(f107a, real32), Sflux=real(f107, real32), ap=real(Ap7, real32), &
+  Tn=T(2), Tex=T(1), Dn=D)
+
+!> translate to old gtd7 convention
+Dn(1) = D(5)  !< He
+Dn(2) = D(4)  !< O
+Dn(3) = D(2)  !< N2
+Dn(4) = D(3)  !< O2
+Dn(5) = D(7)  !< Ar
+Dn(6) = D(1)  !< Total mass density
+Dn(7) = D(6)  !< H
+Dn(8) = D(8)  !< N
+Dn(9) = D(9)  !< Anomalous O
+!! D(10) will be NO in future MSIS 2.x
+
+Tn = real(T, real64)
+
+end subroutine msis_gtd8_r64
+
+
+subroutine msis_gtd8_r32(doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7, Dn, Tn, use_meters)
+!! translate MSIS 2.0 to MSISE00 gtd7-like
+!! assume MSIS 2.0 is also real32
+real(real32), intent(in) :: doy, UTsec, alt_km, glat, glon, f107a, f107, Ap7(7)
+real(real32), intent(out) :: Dn(9), Tn(2)
+logical, intent(in) :: use_meters
+
+real(real32) :: D(10)
+
+call msiscalc(day=doy, UTsec=UTsec, &
+  z=alt_km, lat=glat, lon=glon, &
+  SfluxAvg=f107a, Sflux=f107, ap=Ap7, &
+  Tn=Tn(2), Tex=Tn(1), Dn=D)
+
+!> translate to old gtd7 convention
+Dn(1) = D(5)  !< He
+Dn(2) = D(4)  !< O
+Dn(3) = D(2)  !< N2
+Dn(4) = D(3)  !< O2
+Dn(5) = D(7)  !< Ar
+Dn(6) = D(1)  !< Total mass density
+Dn(7) = D(6)  !< H
+Dn(8) = D(8)  !< N
+Dn(9) = D(9)  !< Anomalous O
+!! D(10) will be NO in future MSIS 2.x
+
+end subroutine msis_gtd8_r32
 
 end module


### PR DESCRIPTION
MSIS 2.0 was implemented as a distinct project without modifying its source code. It automatically downloads and builds when requested via:

```sh
cmake -B build -Dmsis20=yes
cmake --build build
```

MSIS 2.0 is also available in the `msis_setup` executable by specifying the fourth command line parameter `0` or `20` (default `0`)
e.g.
```sh
msis_setup.exe - - 168 20
```
where the dashes indicate to use `stdin` and `stdout` pipes respectively, 168 is an arbitrary number of altitudes (sanity check) and `20` indicates to use MSIS 2.0

This is accomplished in [cmake/msis2.cmake](https://github.com/gemini3d/gemini3d/commit/62c35963af40c9b180bb882ceb5ddc4ce69fb4c1)

I made a generic interface that allows this and future MSIS versions to be seamlessly switched from config.nml. If the .nml requested MSIS version isn't present in gemini.bin, an `error stop` message tells the user what CMake options to recompile with.

The CI tests don't pass with MSIS 2.0 on because of few percent changes in output state. This is a tame, expected difference due to different neutral atmospheric densities and temperatures from MSIS 2.0